### PR TITLE
print to console also for non dev

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -5,9 +5,6 @@
   <springProperty scope="context" name="springAppName" source="spring.application.name"/>
 
   <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
-    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-      <level>DEBUG</level>
-    </filter>
     <encoder>
       <pattern>
         timestamp="%d{"yyyy-MM-dd'T'HH:mm:ss.SSSXXX", UTC}", level="%level", hostname="${HOSTNAME}", pid="${PID:-}", thread="%thread", class="%logger{40}", message="%replace(%replace(%m){'[\r\n]+', ', '}){'"', '\''}", trace="%X{traceId}", span="%X{spanId}", %X%n
@@ -40,6 +37,7 @@
 
   <springProfile name="!dev">
     <root level="INFO">
+      <appender-ref ref="console" />
       <appender-ref ref="file"/>
     </root>
   </springProfile>


### PR DESCRIPTION
Change logback so we also print to the console. We need this since we feed logfiles to splunk and don't have persistant docker containers (so during a crash the log files are lost).