### PR TITLE
add migration to increase uploader_signature column size

### DIFF
--- a/src/main/resources/db/changelog.yml
+++ b/src/main/resources/db/changelog.yml
@@ -38,5 +38,6 @@ databaseChangeLog:
   - include:
       file: changelog/v001-change-certificate-signature-column-size.yml
       relativeToChangelogFile: true
-
-
+  - include:
+    file: changelog/v003-increase-column-size-for-batchsignature.yml
+    relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/v003-increase-column-size-for-batchsignature.yml
+++ b/src/main/resources/db/changelog/v003-increase-column-size-for-batchsignature.yml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: increase-column-size-for-batchsignature
+      author: ubamrein
+      changes:
+        - modifyDataType:
+            tableName: diagnosiskey
+            columnName: uploader_information_batch_signature
+            newDataType: varchar(8000)


### PR DESCRIPTION
Since new certificates are issued with a 4096 bit key, we need to double the signature field (it includes the signing certificate in the binary format).