### PR TITLE
psql: fix create_certificate_signature.sh script (base64)

### DIFF
--- a/tools/create_certificate_signature.sh
+++ b/tools/create_certificate_signature.sh
@@ -24,7 +24,7 @@ openssl base64 -in sig.tmp -out signature.base64 -A
 echo ... saved to signature.base64
 signature=$(cat signature.base64)
 
-cert_base64=$(cat ${certFileName} | base64)
+cert_base64=$(cat ${certFileName} | openssl base64 -A)
 #echo $cert_base64
 
 openssl x509 -fingerprint -sha256 -in ${certFileName} -noout > fingerprint.sha256

--- a/tools/create_certificate_signature.sh
+++ b/tools/create_certificate_signature.sh
@@ -49,7 +49,7 @@ purpose='SIGNING'
 fi
 
 
-template="INSERT INTO certificate VALUES(NULL, '$currentdate', '$fingerprint', '$country', '$purpose', FALSE, NULL, '$signature', FROM_BASE64('$cert_base64'))";
+template="INSERT INTO certificate VALUES(DEFAULT, '$currentdate', '$fingerprint', '$country', '$purpose', FALSE, NULL, '$signature', convert_from(decode('$cert_base64', 'base64'), 'utf-8'))";
 echo $template > insert.sql
 
 echo [4 of 4] Cleaning up...


### PR DESCRIPTION
This PR fixes the generated SQL query to work with psql dbs and switches to `openssl base64` since GNU and BSD `base64` work differently